### PR TITLE
Implemented password reset functionality

### DIFF
--- a/server/prisma/migrations/20251026002443_add_password_reset_token/migration.sql
+++ b/server/prisma/migrations/20251026002443_add_password_reset_token/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable
+CREATE TABLE "PasswordResetToken" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "used" BOOLEAN NOT NULL DEFAULT false,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PasswordResetToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PasswordResetToken_tokenHash_key" ON "PasswordResetToken"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX "PasswordResetToken_userId_idx" ON "PasswordResetToken"("userId");
+
+-- CreateIndex
+CREATE INDEX "PasswordResetToken_expiresAt_idx" ON "PasswordResetToken"("expiresAt");
+
+-- CreateIndex
+CREATE INDEX "PasswordResetToken_tokenHash_idx" ON "PasswordResetToken"("tokenHash");
+
+-- AddForeignKey
+ALTER TABLE "PasswordResetToken" ADD CONSTRAINT "PasswordResetToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/migrations/20251026020131_add_password_history/migration.sql
+++ b/server/prisma/migrations/20251026020131_add_password_history/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "PasswordHistory" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "oldHash" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PasswordHistory_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PasswordHistory_oldHash_key" ON "PasswordHistory"("oldHash");
+
+-- CreateIndex
+CREATE INDEX "PasswordHistory_userId_idx" ON "PasswordHistory"("userId");
+
+-- CreateIndex
+CREATE INDEX "PasswordHistory_oldHash_idx" ON "PasswordHistory"("oldHash");
+
+-- AddForeignKey
+ALTER TABLE "PasswordHistory" ADD CONSTRAINT "PasswordHistory_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -25,6 +25,7 @@ model User {
   updatedAt          DateTime                 @updatedAt
   verificationTokens EmailVerificationToken[]
   resetTokens        PasswordResetToken[]
+  passwordHistory    PasswordHistory[]
 }
 
 // Email verification tokens model
@@ -57,4 +58,17 @@ model PasswordResetToken {
   @@index([userId])
   @@index([expiresAt])
   @@index([tokenHash])
+}
+
+// Password history model for preventing password recycling during password resets
+model PasswordHistory {
+  id        String   @id @default(uuid())
+  userId    String
+  oldHash   String   @unique
+  createdAt DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([oldHash])
 }

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -24,10 +24,27 @@ model User {
   createdAt          DateTime                 @default(now())
   updatedAt          DateTime                 @updatedAt
   verificationTokens EmailVerificationToken[]
+  resetTokens        PasswordResetToken[]
 }
 
 // Email verification tokens model
 model EmailVerificationToken {
+  id        String   @id @default(uuid())
+  userId    String
+  tokenHash String   @unique
+  used      Boolean  @default(false)
+  expiresAt DateTime
+  createdAt DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([expiresAt])
+  @@index([tokenHash])
+}
+
+// Password reset token model
+model PasswordResetToken {
   id        String   @id @default(uuid())
   userId    String
   tokenHash String   @unique

--- a/server/src/controllers/AuthController.js
+++ b/server/src/controllers/AuthController.js
@@ -55,6 +55,14 @@ export const register = async (req, res) => {
             },
         });
 
+        // Create a record of the password in the password history table for versioned credentials
+        const passwordHistoryAddition = await prisma.passwordHistory.create({
+            data: {
+                user: newUser.id,
+                oldHash: passwordHash,
+            }
+        })
+
         // Generate an email verification token, hash it, and set it to expire in one hour
         const rawToken = generateRawToken()
         const tokenHash = await hashToken(rawToken)
@@ -321,24 +329,77 @@ export const resetPassword = async (req, res) => {
             })
         }
 
-        // Update the password for this user
+        // Fetch user and their password history
+        const user = await prisma.user.findUnique(
+            { where: { id },
+                include: { passwordHistory: {orderBy: { createdAt: "desc" } }, },
+            }
+            );
+        if (!user) {
+            return res.status(404).json({
+                message: "User not found"
+            })
+        }
+
+        const history = user.passwordHistory.slice(0, 5);
+        for (const oldPassword of history) {
+            const recycled = await bcrypt.compare(password, oldPassword.oldHash);
+            if (recycled) {
+                return res.status(400).json({
+                    message: "Ensure you are not using any previous password"
+                })
+            }
+        }
+
+        // Hash the new password
         const passwordHash = await bcrypt.hash(password, 10);
-        await prisma.user.update(
-            {
+
+        // I'm using transactions to do multiple database operations at once, to keep it atomic
+        await prisma.$transaction(async (tx) => {
+
+            // Update the users password with the new one
+            await tx.user.update({
                 where: {
-                    id: id,
+                    id
                 },
                 data: {
                     passwordHash
+                },
                 }
-            }
-        );
+            );
 
-        // Deleting the password reset tokens for this user, as they are one-time use
-        await prisma.passwordResetToken.deleteMany({
-            where: {
-                id
+            // Add this password to the password history table
+            await tx.passwordHistory.create({
+                data: {
+                    userId: id,
+                    oldHash: passwordHash,
+                },
+            });
+
+            // Get their previous passwords in descending order by data created
+            const previousHistory = await tx.passwordHistory.findMany({
+                where: {
+                    userId: id,
+                },
+                orderBy: { createdAt: "desc" },
+            });
+
+            // If there is more than 5 passwords, delete the oldest one
+            if (previousHistory.length > 5) {
+                const oldestPassword = previousHistory.slice(5)
+                await tx.passwordHistory.deleteMany({
+                    where: {
+                        id: { in: oldestPassword.map((old) => old.id) },
+                    }
+                });
             }
+
+            // Delete the password reset tokens as they are on-time use
+            await tx.passwordResetToken.deleteMany({
+                where: {
+                    id
+                },
+            });
         });
 
         return res.json({

--- a/server/src/controllers/AuthController.js
+++ b/server/src/controllers/AuthController.js
@@ -228,3 +228,51 @@ export const resendVerification = async (req, res) => {
         res.status(500).json({ message: "Server error" });
     }
 };
+
+export const requestPasswordReset = async (req, res) => {
+
+    try {
+        // Validating the data received
+        const errors = validationResult(req);
+        if (!errors.isEmpty()) {
+            return res.status(400).json({
+                errors: errors.array()
+            });
+        }
+
+        // Deconstruct the request payload, and finding the user with the given email (if applicable)
+        const {email} = req.body;
+        const user = await prisma.user.findUnique({where: {email}});
+        if (!user) {
+            return res.json({
+                message: 'If an account exists, a link was sent.',
+            });
+        }
+
+        // Generate a password reset token, hashing it, and setting it to expire in 30 minutes
+        const rawToken = generateRawToken();
+        const tokenHash = hashToken(rawToken);
+        const expiresAt = new Date(Date.now() + 30 * 60 * 1000);
+
+        // Create a PasswordResetToken and store it in the db
+        await prisma.passwordResetToken.create({
+            data: {
+                userId: user.id,
+                tokenHash,
+                expiresAt
+            }
+        })
+
+        // Add the password reset email request to the background queue
+        await addEmailJobToQueue(user.email, rawToken, user.id, "sendPasswordResetEmail");
+
+        return res.json(
+            {message: "If an account exists, a reset link has been sent."}
+        );
+    } catch (err) {
+        return res.status(500).json({
+            message: 'Server error!'
+        });
+    }
+
+}

--- a/server/src/controllers/AuthController.js
+++ b/server/src/controllers/AuthController.js
@@ -229,6 +229,7 @@ export const resendVerification = async (req, res) => {
     }
 };
 
+// Requesting a password reset email endpoint logic
 export const requestPasswordReset = async (req, res) => {
 
     try {
@@ -274,5 +275,78 @@ export const requestPasswordReset = async (req, res) => {
             message: 'Server error!'
         });
     }
+}
 
+// Resetting a user's password endpoint logic
+export const resetPassword = async (req, res) => {
+
+    try {
+
+        // Validating the data received
+        const errors = validationResult(req);
+        if (!errors.isEmpty()) {
+            return res.status(400).json({
+                errors: errors.array()
+            })
+        }
+
+        // Deconstructing the request payload and ensuring a valid token and password exist
+        const { token, id, password } = req.body;
+        if (!token || !id || !password) {
+            return res.status(400).json({
+                message: "Invalid verification link"
+            })
+        }
+
+        //Finding the password reset token that's valid and assigned to this user
+        const record = await prisma.passwordResetToken.findFirst({
+            where: {
+                id, expiresAt: { gt: new Date() }
+            },
+            orderBy: { createdAt: "desc" },
+        });
+
+        // Indicating if an expired, non-existent, or invalid token is presented
+        if (!record) {
+            return res.status(400).json({
+                message: "Token not found or expired"
+            })
+        }
+
+        // Verifying the token with the stored hashed token
+        const validToken = await verifyToken(token, record.tokenHash);
+        if (!validToken) {
+            return res.status(400).json({
+                message: "Invalid token"
+            })
+        }
+
+        // Update the password for this user
+        const passwordHash = await bcrypt.hash(password, 10);
+        await prisma.user.update(
+            {
+                where: {
+                    id: id,
+                },
+                data: {
+                    passwordHash
+                }
+            }
+        );
+
+        // Deleting the password reset tokens for this user, as they are one-time use
+        await prisma.passwordResetToken.deleteMany({
+            where: {
+                id
+            }
+        });
+
+        return res.json({
+            message: "Password reset successfully."
+        })
+    } catch (err) {
+        return res.status(500).json({
+            message: "Server error!"
+        })
+    }
 }

--- a/server/src/controllers/AuthController.js
+++ b/server/src/controllers/AuthController.js
@@ -70,7 +70,7 @@ export const register = async (req, res) => {
         });
 
         // Add the email request to the queue
-        await addEmailJobToQueue(newUser.email, rawToken, newUser.id)
+        await addEmailJobToQueue(newUser.email, rawToken, newUser.id, "sendVerificationEmail")
 
         // Return the success response
         return res.status(201).json({
@@ -220,7 +220,7 @@ export const resendVerification = async (req, res) => {
         });
 
         // Add the email request to the queue
-        await addEmailJobToQueue(email, rawToken, user.id)
+        await addEmailJobToQueue(email, rawToken, user.id, "sendVerificationEmail");
 
         return res.json({ message: "Verification email sent" });
     } catch (err) {

--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -5,7 +5,8 @@ import {
     login,
     verifyEmail,
     resendVerification,
-    requestPasswordReset
+    requestPasswordReset,
+    resetPassword
 } from '../controllers/AuthController.js';
 
 // Express router paths for auth routes
@@ -41,11 +42,29 @@ router.post(
 router.get("/verify-email", verifyEmail);
 router.post("/resend-verification", resendVerification);
 
-// Request password reset route
+// Request password reset and reset password routes
 router.post("/request-reset",
     [
         body("email").isEmail().withMessage("Valid email required"),
     ],
     requestPasswordReset);
+
+router.post("/reset-password",
+    [
+        body("token").notEmpty(),
+        body("id").notEmpty(),
+        body('password').isLength({ min: 8 })
+            .withMessage('Password must be at least 8 characters long.')
+            .matches(/[a-z]/)
+            .withMessage('Password must contain a lowercase letter.')
+            .matches(/[A-Z]/)
+            .withMessage('Password must contain an uppercase letter.')
+            .matches(/\d/)
+            .withMessage('Password must contain a number.')
+            .matches(/[\W_]/)
+            .withMessage('Password must contain a special character.'),
+    ],
+    resetPassword
+)
 
 export default router;

--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -4,7 +4,8 @@ import {
     register,
     login,
     verifyEmail,
-    resendVerification
+    resendVerification,
+    requestPasswordReset
 } from '../controllers/AuthController.js';
 
 // Express router paths for auth routes
@@ -39,5 +40,12 @@ router.post(
 // Verify email and resend email routes
 router.get("/verify-email", verifyEmail);
 router.post("/resend-verification", resendVerification);
+
+// Request password reset route
+router.post("/request-reset",
+    [
+        body("email").isEmail().withMessage("Valid email required"),
+    ],
+    requestPasswordReset);
 
 export default router;

--- a/server/src/services/emailQueue.js
+++ b/server/src/services/emailQueue.js
@@ -1,6 +1,6 @@
 import { Queue, Worker } from 'bullmq'
 import IORedis from 'ioredis'
-import { sendVerificationEmail} from "./mailer.js";
+import {sendPasswordResetEmail, sendVerificationEmail} from "./mailer.js";
 import dotenv from 'dotenv'
 
 dotenv.config()
@@ -18,8 +18,8 @@ const connection = new IORedis(
 export const emailQueue = new Queue("emails", { connection })
 
 // Add an email job to the queue
-export function addEmailJobToQueue(email, token, userId) {
-    const job = emailQueue.add("sendVerificationEmail", {email, token, userId})
+export function addEmailJobToQueue(email, token, userId, emailType) {
+    const job = emailQueue.add(emailType, {email, token, userId})
     console.log(`Added job for userId=${userId}, email=${email}`);
     return job;
 }
@@ -32,6 +32,11 @@ export const emailWorker = new Worker(
         if (job.name === "sendVerificationEmail") {
             const { email, token, userId } = job.data;
             await sendVerificationEmail(email, token, userId);
+            console.log(`Email sent for userId=${userId}, email=${email}`);
+        }
+        else if (job.name === "sendPasswordResetEmail") {
+            const { email, token, userId } = job.data;
+            await sendPasswordResetEmail(email, token, userId);
             console.log(`Email sent for userId=${userId}, email=${email}`);
         }
     },

--- a/server/src/services/mailer.js
+++ b/server/src/services/mailer.js
@@ -26,3 +26,32 @@ export async function sendVerificationEmail(email, token, userId) {
     `,
     });
 }
+
+// Method for sending an email to a user for email verification
+export async function sendPasswordResetEmail(email, token, userId) {
+
+    const verifyUrl = `${process.env.API_URL}/api/auth/reset-password?token=${token}&id=${userId}`;
+
+    return await resend.emails.send({
+        from: "RoommateLink <onboarding@resend.dev>",
+        to: email,
+        subject: "Reset your password",
+        html: `
+      <div style="font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial">
+        <h1>Reset password request</h1>
+        <p>We received a request to reset your password. Click the button below.</p>
+        <p><a href="${verifyUrl}"
+              style="display:inline-block;padding:10px 16px;background:#0f766e;color:#fff;
+                     text-decoration:none;border-radius:8px;">Reset Password</a></p>
+        <p>If the button doesn't work, copy this URL:</p>
+        <p style="word-break:break-all">${verifyUrl}</p>
+        <p style="color:#6b7280;font-size:12px;margin-top:12px">
+          If you didn’t request this, you can ignore this email.
+        </p>
+        <p style="color:#6b7280;font-size:12px;margin-top:12px">
+          For your security, this link will expire in 30 minutes or once used
+        </p>
+      </div>
+    `,
+    });
+}


### PR DESCRIPTION
In this pull request, the following was implemented:

1. The email template for password reset emails was created, and the emailQueue.js file was updated to incorporate this additional job type
2. Added a PasswordResetToken model, which stores reset tokens and assigns them to users to allow for verification 
3. Completed the /request-reset endpoint, which gets a request for a password reset and adds a job to the background queue for sending a password reset email to the user
4. Completed the /reset-password endpoint, which validates a user's reset link, hashes their password, and updates their password
5. Implemented previous N password check to ensure that when a user registers or resets their password, their password is added to the versioned PasswordHistory table, which will ensure passwords aren't being recycled

Closes #10, #11, #16, and #26 