### PR TITLE
Refactored password reset to use mobile-friendly flow

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -20,6 +20,7 @@
         "jsonwebtoken": "^9.0.2",
         "nodemailer": "^7.0.9",
         "nodemon": "^3.1.10",
+        "otplib": "^12.0.1",
         "pg": "^8.16.3",
         "resend": "^6.1.2"
       },
@@ -110,6 +111,53 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@otplib/core": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/core/-/core-12.0.1.tgz",
+      "integrity": "sha512-4sGntwbA/AC+SbPhbsziRiD+jNDdIzsZ3JUyfZwjtKyc/wufl1pnSIaG4Uqx8ymPagujub0o92kgBnB89cuAMA==",
+      "license": "MIT"
+    },
+    "node_modules/@otplib/plugin-crypto": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz",
+      "integrity": "sha512-qPuhN3QrT7ZZLcLCyKOSNhuijUi9G5guMRVrxq63r9YNOxxQjPm59gVxLM+7xGnHnM6cimY57tuKsjK7y9LM1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1"
+      }
+    },
+    "node_modules/@otplib/plugin-thirty-two": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-thirty-two/-/plugin-thirty-two-12.0.1.tgz",
+      "integrity": "sha512-MtT+uqRso909UkbrrYpJ6XFjj9D+x2Py7KjTO9JDPhL0bJUYVu5kFP4TFZW4NFAywrAtFRxOVY261u0qwb93gA==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "thirty-two": "^1.0.2"
+      }
+    },
+    "node_modules/@otplib/preset-default": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/preset-default/-/preset-default-12.0.1.tgz",
+      "integrity": "sha512-xf1v9oOJRyXfluBhMdpOkr+bsE+Irt+0D5uHtvg6x1eosfmHCsCC6ej/m7FXiWqdo0+ZUI6xSKDhJwc8yfiOPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/plugin-crypto": "^12.0.1",
+        "@otplib/plugin-thirty-two": "^12.0.1"
+      }
+    },
+    "node_modules/@otplib/preset-v11": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/preset-v11/-/preset-v11-12.0.1.tgz",
+      "integrity": "sha512-9hSetMI7ECqbFiKICrNa4w70deTUfArtwXykPUvSHWOdzOlfa9ajglu7mNCntlvxycTiOAXkQGwjQCzzDEMRMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/plugin-crypto": "^12.0.1",
+        "@otplib/plugin-thirty-two": "^12.0.1"
+      }
     },
     "node_modules/@prisma/client": {
       "version": "6.17.1",
@@ -1540,6 +1588,17 @@
         "wrappy": "1"
       }
     },
+    "node_modules/otplib": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/otplib/-/otplib-12.0.1.tgz",
+      "integrity": "sha512-xDGvUOQjop7RDgxTQ+o4pOol0/3xSZzawTiPKRrHnQWAy0WjhNs/5HdIDJCrqC4MBynmjXgULc6YfioaxZeFgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/preset-default": "^12.0.1",
+        "@otplib/preset-v11": "^12.0.1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2118,6 +2177,14 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/thirty-two": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/thirty-two/-/thirty-two-1.0.2.tgz",
+      "integrity": "sha512-OEI0IWCe+Dw46019YLl6V10Us5bi574EvlJEOcAkB29IzQ/mYD1A6RyNHLjZPiHCmuodxvgF6U+vZO1L15lxVA==",
+      "engines": {
+        "node": ">=0.2.6"
       }
     },
     "node_modules/tinyexec": {

--- a/server/package.json
+++ b/server/package.json
@@ -23,6 +23,7 @@
     "jsonwebtoken": "^9.0.2",
     "nodemailer": "^7.0.9",
     "nodemon": "^3.1.10",
+    "otplib": "^12.0.1",
     "pg": "^8.16.3",
     "resend": "^6.1.2"
   },

--- a/server/prisma/migrations/20251029202403_password_reset_use_code/migration.sql
+++ b/server/prisma/migrations/20251029202403_password_reset_use_code/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `used` on the `EmailVerificationToken` table. All the data in the column will be lost.
+  - You are about to drop the column `used` on the `PasswordResetToken` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "EmailVerificationToken" DROP COLUMN "used";
+
+-- AlterTable
+ALTER TABLE "PasswordResetToken" DROP COLUMN "used";

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -33,7 +33,6 @@ model EmailVerificationToken {
   id        String   @id @default(uuid())
   userId    String
   tokenHash String   @unique
-  used      Boolean  @default(false)
   expiresAt DateTime
   createdAt DateTime @default(now())
 
@@ -49,7 +48,6 @@ model PasswordResetToken {
   id        String   @id @default(uuid())
   userId    String
   tokenHash String   @unique
-  used      Boolean  @default(false)
   expiresAt DateTime
   createdAt DateTime @default(now())
 

--- a/server/src/controllers/AuthController.js
+++ b/server/src/controllers/AuthController.js
@@ -4,7 +4,7 @@ import jwt from 'jsonwebtoken';
 import { validationResult } from 'express-validator';
 import { generateRawToken, hashToken, verifyToken} from "../utils/token.js";
 import { addEmailJobToQueue} from "../services/emailQueue.js";
-import {generateOTP, verifyOTP} from "../utils/otp.js";
+import {generateOTP, hashOTP, verifyOTP} from "../utils/otp.js";
 
 // Auth controller that contains the different authentication methods
 
@@ -320,7 +320,7 @@ export const requestPasswordReset = async (req, res) => {
 
         // Generate a password reset OTP, hash it, and set it to expire in 15 minutes
         const rawOTP = generateOTP();
-        const otpHash = await hashToken(rawOTP);
+        const otpHash = await hashOTP(rawOTP);
         const expiresAt = new Date(Date.now() + 15 * 60 * 1000);
 
         // Create a PasswordResetToken and store it in the db

--- a/server/src/controllers/AuthController.js
+++ b/server/src/controllers/AuthController.js
@@ -244,6 +244,14 @@ export const resendVerification = async (req, res) => {
 export const verifyResetOTP = async (req, res) => {
     try {
 
+        // Validating the request contents
+        const errors = validationResult(req);
+        if (!errors.isEmpty()) {
+            return res.status(400).json({
+                errors: errors.array()
+            })
+        }
+
         // Deconstructing the payload and getting the email and entered OTP
         const { email, otp } = req.body;
 
@@ -328,7 +336,7 @@ export const requestPasswordReset = async (req, res) => {
         await addEmailJobToQueue(user.email, rawOTP, user.id, "sendPasswordResetEmail");
 
         return res.json(
-            {message: "If an account exists, a reset link has been sent."}
+            {message: "If an account exists, a reset code has been sent."}
         );
     } catch (err) {
         return res.status(500).json({
@@ -337,8 +345,6 @@ export const requestPasswordReset = async (req, res) => {
         });
     }
 }
-
-
 
 // Resetting a user's password endpoint logic
 export const resetPassword = async (req, res) => {
@@ -354,39 +360,16 @@ export const resetPassword = async (req, res) => {
         }
 
         // Deconstructing the request payload and ensuring a valid token and password exist
-        const { token, id, password, password_confirmation } = req.body;
-        if (!token || !id || !password || !password_confirmation) {
+        const { userId, password, password_confirmation } = req.body;
+        if (!userId || !password || !password_confirmation) {
             return res.status(400).json({
-                message: "Invalid verification link"
-            })
-        }
-
-        //Finding the password reset token that's valid and assigned to this user
-        const record = await prisma.passwordResetToken.findFirst({
-            where: {
-                userId: id, expiresAt: { gt: new Date() }
-            },
-            orderBy: { createdAt: "desc" },
-        });
-
-        // Indicating if an expired, non-existent, or invalid token is presented
-        if (!record) {
-            return res.status(400).json({
-                message: "Token not found or expired"
-            })
-        }
-
-        // Verifying the token with the stored hashed token
-        const validToken = await verifyToken(token, record.tokenHash);
-        if (!validToken) {
-            return res.status(400).json({
-                message: "Invalid token"
+                message: "Missing fields"
             })
         }
 
         // Fetch user and their password history
         const user = await prisma.user.findUnique(
-            { where: { id },
+            { where: { id: userId },
                 include: { passwordHistory: {orderBy: { createdAt: "desc" } }, },
             }
             );
@@ -427,7 +410,7 @@ export const resetPassword = async (req, res) => {
             // Update the users password with the new one
             await tx.user.update({
                 where: {
-                    id
+                    userId
                 },
                 data: {
                     passwordHash
@@ -438,7 +421,7 @@ export const resetPassword = async (req, res) => {
             // Add this password to the password history table
             await tx.passwordHistory.create({
                 data: {
-                    userId: id,
+                    userId,
                     oldHash: passwordHash,
                 },
             });
@@ -460,13 +443,6 @@ export const resetPassword = async (req, res) => {
                     }
                 });
             }
-
-            // Delete the password reset tokens as they are one-time use
-            await tx.passwordResetToken.deleteMany({
-                where: {
-                    userId: id
-                },
-            });
         });
 
         return res.json({

--- a/server/src/controllers/AuthController.js
+++ b/server/src/controllers/AuthController.js
@@ -4,6 +4,7 @@ import jwt from 'jsonwebtoken';
 import { validationResult } from 'express-validator';
 import { generateRawToken, hashToken, verifyToken} from "../utils/token.js";
 import { addEmailJobToQueue} from "../services/emailQueue.js";
+import {generateOTP} from "../utils/otp.js";
 
 // Auth controller that contains the different authentication methods
 
@@ -260,22 +261,22 @@ export const requestPasswordReset = async (req, res) => {
             });
         }
 
-        // Generate a password reset token, hashing it, and setting it to expire in 30 minutes
-        const rawToken = generateRawToken();
-        const tokenHash = await hashToken(rawToken);
-        const expiresAt = new Date(Date.now() + 30 * 60 * 1000);
+        // Generate a password reset OTP, hash it, and set it to expire in 15 minutes
+        const rawOTP = generateOTP();
+        const otpHash = await hashToken(rawOTP);
+        const expiresAt = new Date(Date.now() + 15 * 60 * 1000);
 
         // Create a PasswordResetToken and store it in the db
         await prisma.passwordResetToken.create({
             data: {
                 userId: user.id,
-                tokenHash,
+                tokenHash: otpHash,
                 expiresAt
             }
         })
 
         // Add the password reset email request to the background queue
-        await addEmailJobToQueue(user.email, rawToken, user.id, "sendPasswordResetEmail");
+        await addEmailJobToQueue(user.email, rawOTP, user.id, "sendPasswordResetEmail");
 
         return res.json(
             {message: "If an account exists, a reset link has been sent."}

--- a/server/src/controllers/AuthController.js
+++ b/server/src/controllers/AuthController.js
@@ -4,7 +4,7 @@ import jwt from 'jsonwebtoken';
 import { validationResult } from 'express-validator';
 import { generateRawToken, hashToken, verifyToken} from "../utils/token.js";
 import { addEmailJobToQueue} from "../services/emailQueue.js";
-import {generateOTP} from "../utils/otp.js";
+import {generateOTP, verifyOTP} from "../utils/otp.js";
 
 // Auth controller that contains the different authentication methods
 
@@ -240,6 +240,55 @@ export const resendVerification = async (req, res) => {
     }
 };
 
+// Verify a reset OTP endpoint
+export const verifyResetOTP = async (req, res) => {
+    try {
+
+        // Deconstructing the payload and getting the email and entered OTP
+        const { email, otp } = req.body;
+
+        // If the payload isn;t full indicate such
+        if (!email || !otp) {
+            return res.status(400).json({ message: "Email and OTP are required" });
+        }
+
+        // Get the user with this email
+        const user = await prisma.user.findUnique({ where: { email } });
+        const userId = user.id;
+
+        // Find the latest unexpired OTP for this user
+        const record = await prisma.passwordResetToken.findFirst({
+            where: {
+                userId,
+                expiresAt: { gt: new Date() }
+            },
+            orderBy: { createdAt: "desc" },
+        });
+
+        // Indicate if not OTP was found
+        if (!record) {
+            return res.status(400).json({ message: "OTP not found or expired" });
+        }
+
+        // Verify OTP using timing-safe comparison
+        const isValid = verifyOTP(otp, record.tokenHash);
+        if (!isValid) {
+            return res.status(400).json({ message: "Invalid OTP" });
+        }
+
+        // Delete all OTP once used
+        await prisma.passwordResetToken.deleteMany({
+            where: { userId }
+        });
+
+        // Respond with success message
+        return res.json({ message: "OTP verified", userId: record.userId });
+    } catch (err) {
+        console.error(err);
+        return res.status(500).json({ message: "Server error", error: err });
+    }
+}
+
 // Requesting a password reset email endpoint logic
 export const requestPasswordReset = async (req, res) => {
 
@@ -288,6 +337,8 @@ export const requestPasswordReset = async (req, res) => {
         });
     }
 }
+
+
 
 // Resetting a user's password endpoint logic
 export const resetPassword = async (req, res) => {

--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -53,7 +53,7 @@ router.post("/request-reset",
 router.post('/verify-reset-otp',
     [
         body("email").isEmail().withMessage("Valid email required"),
-        body("otp").notEmpty().withMessage("Valid OTP number required"),
+        body("otp").notEmpty().withMessage("Valid OTP number required").isLength({min: 6, max: 6}),
     ],
     verifyResetOTP
     )

--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -60,8 +60,7 @@ router.post('/verify-reset-otp',
 
 router.post("/reset-password",
     [
-        body("token").notEmpty(),
-        body("id").notEmpty(),
+        body("userId").notEmpty(),
         body('password').isLength({ min: 8 })
             .withMessage('Password must be at least 8 characters long.')
             .matches(/[a-z]/)

--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -6,7 +6,7 @@ import {
     verifyEmail,
     resendVerification,
     requestPasswordReset,
-    resetPassword
+    resetPassword, verifyResetOTP
 } from '../controllers/AuthController.js';
 
 // Express router paths for auth routes
@@ -48,6 +48,15 @@ router.post("/request-reset",
         body("email").isEmail().withMessage("Valid email required"),
     ],
     requestPasswordReset);
+
+// Verify OTP reset endpoint
+router.post('/verify-reset-otp',
+    [
+        body("email").isEmail().withMessage("Valid email required"),
+        body("otp").notEmpty().withMessage("Valid OTP number required"),
+    ],
+    verifyResetOTP
+    )
 
 router.post("/reset-password",
     [

--- a/server/src/services/emailQueue.js
+++ b/server/src/services/emailQueue.js
@@ -36,7 +36,7 @@ export const emailWorker = new Worker(
         }
         else if (job.name === "sendPasswordResetEmail") {
             const { email, token, userId } = job.data;
-            await sendPasswordResetEmail(email, token, userId);
+            await sendPasswordResetEmail(email, token);
             console.log(`Email sent for userId=${userId}, email=${email}`);
         }
     },

--- a/server/src/services/mailer.js
+++ b/server/src/services/mailer.js
@@ -28,28 +28,21 @@ export async function sendVerificationEmail(email, token, userId) {
 }
 
 // Method for sending an email to a user for email verification
-export async function sendPasswordResetEmail(email, token, userId) {
-
-    const verifyUrl = `${process.env.API_URL}/api/auth/reset-password?token=${token}&id=${userId}`;
-
+export async function sendPasswordResetEmail(email, code) {
     return await resend.emails.send({
         from: "RoommateLink <onboarding@resend.dev>",
         to: email,
-        subject: "Reset your password",
+        subject: "Your password reset code",
         html: `
       <div style="font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial">
-        <h1>Reset password request</h1>
-        <p>We received a request to reset your password. Click the button below.</p>
-        <p><a href="${verifyUrl}"
-              style="display:inline-block;padding:10px 16px;background:#0f766e;color:#fff;
-                     text-decoration:none;border-radius:8px;">Reset Password</a></p>
-        <p>If the button doesn't work, copy this URL:</p>
-        <p style="word-break:break-all">${verifyUrl}</p>
+        <h1>Password Reset Request</h1>
+        <p>We received a request to reset your password. Enter the code below in the app to continue.</p>
+        <h2 style="font-size:24px;margin:16px 0;color:#0f766e">${code}</h2>
         <p style="color:#6b7280;font-size:12px;margin-top:12px">
-          If you didn’t request this, you can ignore this email.
+          For your security, this code will expire in 10 minutes.
         </p>
         <p style="color:#6b7280;font-size:12px;margin-top:12px">
-          For your security, this link will expire in 30 minutes or once used
+          If you didn’t request this, you can ignore this email.
         </p>
       </div>
     `,

--- a/server/src/utils/otp.js
+++ b/server/src/utils/otp.js
@@ -1,0 +1,16 @@
+import crypto from "crypto";
+
+// Generate a secure random 6-digit OTP
+export function generateOTP() {
+    const otp = crypto.randomInt(100000, 999999);
+}
+
+// Hash the OTP for storing in the database
+export async function hashOTP(otp) {
+    return crypto.createHash('sha256').update(otp).digest('hex');
+}
+
+// Verifying a raw token matches the stored hash
+export async function verifyOTP(raw, hash) {
+    return crypto.createHash("sha256").update(raw).digest("hex") === hash;
+}

--- a/server/src/utils/otp.js
+++ b/server/src/utils/otp.js
@@ -2,7 +2,7 @@ import crypto from "crypto";
 
 // Generate a secure random 6-digit OTP
 export function generateOTP() {
-    const otp = crypto.randomInt(100000, 999999);
+    return crypto.randomInt(100000, 999999);
 }
 
 // Hash the OTP for storing in the database


### PR DESCRIPTION
In this pull request, the following was implemented:

1. The password reset now uses a 6-digit OTP that is sent to the user's email and expires after 15 minutes
2. The /verify-reset-otp endpoint verifies an entered OTP to the user's stored OTP before prompting access to the reset password page
3. The /password-reset logic changes, as it is not doing token verification as that is part of a new endpoint

Closes #34 
